### PR TITLE
Keep values that are right censored

### DIFF
--- a/R/compressData.r
+++ b/R/compressData.r
@@ -82,17 +82,17 @@ compressData <- function(data, verbose = TRUE, interactive=NULL){
     }
   }
   
-  flaggedData2 <- returnDataFrame[(returnDataFrame$ConcLow > returnDataFrame$ConcHigh),]
-  returnDataFrame <- returnDataFrame[(returnDataFrame$ConcLow <= returnDataFrame$ConcHigh),]
-  
-  if (nrow(flaggedData2) > 0){
-    WarningMessage <- paste("Deleted", nrow(flaggedData2), "rows of data because the high concentration was reported lower than the low concentration, the program is unable to interpret that result and is therefore deleting it.")    
-    warning(WarningMessage)
-    if (verbose){
-      cat("Deleted Rows:\n")
-      print(flaggedData2)
-    }
-  }
+  # flaggedData2 <- returnDataFrame[(returnDataFrame$ConcLow > returnDataFrame$ConcHigh),]
+  # returnDataFrame <- returnDataFrame[(returnDataFrame$ConcLow <= returnDataFrame$ConcHigh),]
+  # 
+  # if (nrow(flaggedData2) > 0){
+  #   WarningMessage <- paste("Deleted", nrow(flaggedData2), "rows of data because the high concentration was reported lower than the low concentration, the program is unable to interpret that result and is therefore deleting it.")    
+  #   warning(WarningMessage)
+  #   if (verbose){
+  #     cat("Deleted Rows:\n")
+  #     print(flaggedData2)
+  #   }
+  #}
   
   return(returnDataFrame)
 }

--- a/R/compressData.r
+++ b/R/compressData.r
@@ -68,7 +68,7 @@ compressData <- function(data, verbose = TRUE, interactive=NULL){
   returnDataFrame$ConcLow <- as.numeric(lowConcentration)
   returnDataFrame$ConcHigh <- as.numeric(highConcentration)
   Uncen1<-ifelse(returnDataFrame$ConcLow==returnDataFrame$ConcHigh,1,0)
-  returnDataFrame$Uncen<-ifelse(is.na(returnDataFrame$ConcLow),0,Uncen1)
+  returnDataFrame$Uncen<-ifelse(is.na(returnDataFrame$ConcLow)|is.na(returnDataFrame$ConcHigh),0,Uncen1)
   
   flaggedData1 <- returnDataFrame[(returnDataFrame$ConcLow == 0 & returnDataFrame$ConcHigh == 0),]
   returnDataFrame <- returnDataFrame[!(returnDataFrame$ConcLow == 0 & returnDataFrame$ConcHigh == 0),]

--- a/R/populateConcentrations.r
+++ b/R/populateConcentrations.r
@@ -17,7 +17,7 @@ populateConcentrations <- function(rawData){  # rawData is a dataframe with valu
   concentrationColumns$ConcHigh <- as.numeric(ifelse((rawData$code != ">" | is.na(rawData$code)), rawData$value, 0))
   tempConcLow<-ifelse((rawData$code!="<" | is.na(rawData$code)),rawData$value,0)
   tempConcHigh <- ifelse((rawData$code != ">" | is.na(rawData$code)), rawData$value, 0)
-  concentrationColumns$Uncen <- ifelse(tempConcLow==0,0,1)  
+  concentrationColumns$Uncen <- ifelse(tempConcLow == 0 | tempConcHigh == 0, 0, 1)
   #Add if value = NA?
   return (concentrationColumns)  # returns ConcLow, ConcHigh, Uncen (0 if censored, 1 if uncensored)
 }

--- a/R/populateConcentrations.r
+++ b/R/populateConcentrations.r
@@ -14,8 +14,9 @@ populateConcentrations <- function(rawData){  # rawData is a dataframe with valu
   concentrationColumns <- as.data.frame(matrix(ncol=3,nrow=length(rawData$value)))
   colnames(concentrationColumns) <- c('ConcLow','ConcHigh','Uncen')  
   concentrationColumns$ConcLow <- as.numeric(ifelse((rawData$code!="<" | is.na(rawData$code)),rawData$value,0))
-  concentrationColumns$ConcHigh <- as.numeric(rawData$value)
+  concentrationColumns$ConcHigh <- as.numeric(ifelse((rawData$code != ">" | is.na(rawData$code)), rawData$value, 0))
   tempConcLow<-ifelse((rawData$code!="<" | is.na(rawData$code)),rawData$value,0)
+  tempConcHigh <- ifelse((rawData$code != ">" | is.na(rawData$code)), rawData$value, 0)
   concentrationColumns$Uncen <- ifelse(tempConcLow==0,0,1)  
   #Add if value = NA?
   return (concentrationColumns)  # returns ConcLow, ConcHigh, Uncen (0 if censored, 1 if uncensored)

--- a/R/populateSampleColumns.r
+++ b/R/populateSampleColumns.r
@@ -19,14 +19,15 @@ populateSampleColumns <- function(rawData){  # rawData is a dataframe with dateT
   Sample$ConcLow <- rawData$ConcLow
   Sample$ConcHigh <- rawData$ConcHigh
   Sample$Uncen <- rawData$Uncen
-  Sample$ConcAve <- (Sample$ConcLow+Sample$ConcHigh)/2
+  Sample$ConcAve <- ifelse(Sample$ConcHigh == 0, Sample$ConcLow*1.5, (Sample$ConcLow + Sample$ConcHigh)/2)
   Sample$ConcLow <- ifelse((rawData$ConcLow == 0.0 & rawData$Uncen == 0),NA,rawData$ConcLow)
+  Sample$ConcHigh <- ifelse((rawData$ConcHigh == 0 & rawData$Uncen == 0), NA, rawData$ConcHigh)
   
   dateFrame <- populateDateColumns(rawData$dateTime)
   Sample <- cbind(Sample, dateFrame[,-1])
   
   Sample$SinDY <- sin(2*pi*Sample$DecYear)
   Sample$CosDY <- cos(2*pi*Sample$DecYear)
-  Sample2 <- subset(Sample, (!is.na(Sample$ConcHigh)))  # Was just ConcHigh.....
-  return (Sample2)  
+  # Sample2 <- subset(Sample, (!is.na(Sample$ConcHigh)))  # Was just ConcHigh.....
+  return (Sample)  
 }


### PR DESCRIPTION
Modified parts of the `Sample` clean up process so that it recognizes and keeps right-censored (e.g., ">") values. Per `Survival` documentation, the solution I propose for this is to set the ConcLow to censoring level and ConcHigh to NA. ConcAve was calculated as 2*ConcLow for plotting purposes. 

Note this does not solve plotting of right-censored values. For example, `plotConcTime` may plot the censored values as left-censored, whereas the line segment should be drawn upwards instead of downwards. I was having a hard time understanding how `censoredSegments` was implemented.  